### PR TITLE
[mhwd-kernel] add rt-kernel support and some small modifications

### DIFF
--- a/scripts/mhwd-kernel
+++ b/scripts/mhwd-kernel
@@ -9,7 +9,7 @@ args_check() {
 }
 
 err() {
-    printf "\e[31mError:\e[0m $1" 1>&2; exit 1
+    printf "\e[31mError:\e[0m $1\n" 1>&2; exit 1
 }
 
 kernel_usage() {
@@ -27,9 +27,9 @@ kernel_install() {
 
     for kernel in "$@"; do
         [[ $kernel = "rmc" ]] && rmc=1 && continue
-        [[ $kernel != linux[0-9][0-9]?([0-9]) && $kernel != linux-rt-*manjaro && $kernel != "rmc" ]] && err "Invalid argument.\nPlease choose one of the $(kernel_repo)\n"
+        [[ $kernel != linux[0-9][0-9]?([0-9]) && $kernel != linux-rt-*manjaro && $kernel != "rmc" ]] && err "Invalid argument.\nPlease choose one of the $(kernel_repo)"
         [[ $current = $kernel ]] && err "You can't reinstall your current kernel. Please use 'pacman -Syu' instead to update."
-        [[ -z $(pacman -Ssq "^$kernel$") ]] && err "Please make sure if the given kernel(s) exist(s).\n$(kernel_repo)\n"
+        [[ -z $(pacman -Ssq "^$kernel$") ]] && err "Please make sure if the given kernel(s) exist(s).\n$(kernel_repo)"
         
         for pkg in $(pacman -Qqs "$current"); do
             pkg=${pkg//$current/$kernel}
@@ -49,7 +49,7 @@ kernel_install() {
     pacman -S "${pkginstall[@]}"
 
     [[ $rmc = 1 && $? = 0 ]] && pacman -R $(pacman -Qqs $current)
-    [[ $rmc = 1 && $? != 0 ]] && { echo ""; err "'rmc' aborted because the kernel failed to install or canceled on removal.\n"; }
+    [[ $rmc = 1 && $? != 0 ]] && { echo ""; err "'rmc' aborted because the kernel failed to install or canceled on removal."; }
 }
 
 kernel_repo() {
@@ -68,10 +68,10 @@ kernel_remove() {
     pkgremove=()
 
     for kernel in "$@"; do
-        [[ -z "$kernel" ]] && err "Invalid argument (use -h for help).\n"
-        [[ $kernel != linux[0-9][0-9]?([0-9]) && $kernel != linux-rt-*manjaro ]] && err "Please enter a valid kernel name.\n$(kernel_list)\n"
-        [[ $current = $kernel ]] && err "You can't remove your current kernel.\n"
-        [[ -z $(pacman -Qqs "^$1$") ]] && err "Kernel not installed.\n$(kernel_list)\n"
+        [[ -z "$kernel" ]] && err "Invalid argument (use -h for help)."
+        [[ $kernel != linux[0-9][0-9]?([0-9]) && $kernel != linux-rt-*manjaro ]] && err "Please enter a valid kernel name.\n$(kernel_list)"
+        [[ $current = $kernel ]] && err "You can't remove your current kernel."
+        [[ -z $(pacman -Qqs "^$1$") ]] && err "Kernel not installed.\n$(kernel_list)"
 
         for pkg in $(pacman -Qqs "$kernel"); do
             pkgremove+=("$pkg")

--- a/scripts/mhwd-kernel
+++ b/scripts/mhwd-kernel
@@ -59,7 +59,7 @@ kernel_repo() {
 }
 
 kernel_list() {
-    printf "\e[32mCurrently running:\e[0m $(uname -r) (${current}\n"
+    printf "\e[32mCurrently running:\e[0m $(uname -r) (${current})\n"
     echo "The following kernels are installed in your system:"
     pacman -Qqs "^linux[0-9-][0-9r]?.*[0-9o]$" | grep -v "r8" | while read -r; do echo "   * $REPLY"; done
 }

--- a/scripts/mhwd-kernel
+++ b/scripts/mhwd-kernel
@@ -9,7 +9,7 @@ args_check() {
 }
 
 err() {
-    echo "Error: $1" 1>&2; exit 1
+    printf "\e[31mError:\e[0m $1" 1>&2; exit 1
 }
 
 kernel_usage() {
@@ -27,10 +27,9 @@ kernel_install() {
 
     for kernel in "$@"; do
         [[ $kernel = "rmc" ]] && rmc=1 && continue
-        [[ $kernel != linux[0-9][0-9]?([0-9]) && $kernel != "rmc" ]] && err "Invalid argument (use -h for help)."
-        [[ $kernel != linux[0-9][0-9]?([0-9]) ]] && err "Please enter a valid kernel name."
+        [[ $kernel != linux[0-9][0-9]?([0-9]) && $kernel != linux-rt-*manjaro && $kernel != "rmc" ]] && err "Invalid argument.\nPlease choose one of the $(kernel_repo)\n"
         [[ $current = $kernel ]] && err "You can't reinstall your current kernel. Please use 'pacman -Syu' instead to update."
-        [[ -z $(pacman -Ssq "^$kernel$") ]] && err "Please make sure if the given kernel(s) exist(s)."
+        [[ -z $(pacman -Ssq "^$kernel$") ]] && err "Please make sure if the given kernel(s) exist(s).\n$(kernel_repo)\n"
         
         for pkg in $(pacman -Qqs "$current"); do
             pkg=${pkg//$current/$kernel}
@@ -50,28 +49,29 @@ kernel_install() {
     pacman -S "${pkginstall[@]}"
 
     [[ $rmc = 1 && $? = 0 ]] && pacman -R $(pacman -Qqs $current)
-    [[ $rmc = 1 && $? != 0 ]] && { echo ""; err "'rmc' aborted because the kernel failed to install or canceled on removal."; }
+    [[ $rmc = 1 && $? != 0 ]] && { echo ""; err "'rmc' aborted because the kernel failed to install or canceled on removal.\n"; }
 }
 
 kernel_repo() {
-    echo "Available kernels:"
-    pacman -Ss "^linux[0-9][0-9]?([0-9])$" | grep core | while read -r; do echo "   * ${REPLY:5:8}"; done
+    printf "\e[32mavailable kernels:\e[0m\n"
+    pacman -Ssq "^linux[0-9][0-9]?([0-9])$" | while read -r; do echo "   * $REPLY"; done
+    pacman -Ssq "^linux-rt.*([o])$" | while read -r; do echo "   * $REPLY"; done
 }
 
 kernel_list() {
-    echo "Currently running: $(uname -r) (${current})"
+    printf "\e[32mCurrently running:\e[0m $(uname -r) (${current}\n"
     echo "The following kernels are installed in your system:"
-    pacman -Qqs "^linux[0-9][0-9]?([0-9])$" | while read -r; do echo "   * $REPLY"; done
+    pacman -Qqs "^linux[0-9-][0-9r]?.*[0-9o]$" | grep -v "r8" | while read -r; do echo "   * $REPLY"; done
 }
 
 kernel_remove() {
     pkgremove=()
 
     for kernel in "$@"; do
-        [[  -z "$kernel" ]] && err "Invalid argument (use -h for help)."
-        [[ $kernel != linux[0-9][0-9]?([0-9]) ]] && err "Please enter a valid kernel name."
-        [[ $current = $kernel ]] && err "You can't remove your current kernel."
-        [[ -z $(pacman -Qqs "^$1$") ]] && err "Kernel not installed."
+        [[ -z "$kernel" ]] && err "Invalid argument (use -h for help).\n"
+        [[ $kernel != linux[0-9][0-9]?([0-9]) && $kernel != linux-rt-*manjaro ]] && err "Please enter a valid kernel name.\n$(kernel_list)\n"
+        [[ $current = $kernel ]] && err "You can't remove your current kernel.\n"
+        [[ -z $(pacman -Qqs "^$1$") ]] && err "Kernel not installed.\n$(kernel_list)\n"
 
         for pkg in $(pacman -Qqs "$kernel"); do
             pkgremove+=("$pkg")
@@ -82,7 +82,10 @@ kernel_remove() {
 }
 
 IFS=. read -r major minor _ <<< "$(uname -r)"
-current="linux$major$minor"
+basekernel="linux$major$minor"
+current=$basekernel
+[[ $(uname -r) == *rt* ]] && [[ $basekernel == *44 ]] && current=linux-rt-lts-manjaro
+[[ $(uname -r) == *rt* ]] && [[ $basekernel == *46 ]] && current=linux-rt-manjaro
 
 case "$1" in
     -h | --help)            args_check $# 1 1
@@ -105,6 +108,3 @@ case "$1" in
     -*)                     err "Invalid argument (use -h for help)." ;;
     *)                      err "No arguments given (use -h for help)." ;;
 esac
-
-
-

--- a/scripts/mhwd-kernel
+++ b/scripts/mhwd-kernel
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# rt-basekernels
-rt_base=linux46
-rt_lts_base=linux44
+# evaluate rt-basekernels if installed
+[[ $(ls /boot/linux*rt-[xi]* 2>/dev/null | wc -l) != 0 ]] && IFS=. read rt_maj rt_min <<< $(cut -f 1-2 -d '.' /boot/linux*rt-[xi]*) && rt_base=linux$rt_maj$rt_min
+[[ $(ls /boot/linux*rt-l* 2>/dev/null | wc -l) != 0 ]] && IFS=. read rtl_maj rtl_min <<< $(cut -f 1-2 -d '.' /boot/linux*rt-l*) && rt_lts_base=linux$rtl_maj$rtl_min
 
 root_check() {
     [[ $EUID != 0 ]] && err "Please run as root."

--- a/scripts/mhwd-kernel
+++ b/scripts/mhwd-kernel
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# rt-basekernels
+rt_base=linux46
+rt_lts_base=linux44
+
 root_check() {
     [[ $EUID != 0 ]] && err "Please run as root."
 }
@@ -82,10 +86,9 @@ kernel_remove() {
 }
 
 IFS=. read -r major minor _ <<< "$(uname -r)"
-basekernel="linux$major$minor"
-current=$basekernel
-[[ $(uname -r) == *rt* ]] && [[ $basekernel == *44 ]] && current=linux-rt-lts-manjaro
-[[ $(uname -r) == *rt* ]] && [[ $basekernel == *46 ]] && current=linux-rt-manjaro
+current="linux$major$minor"
+[[ $(uname -r) == *rt* ]] && [[ $current == $rt_base ]] && current=linux-rt-manjaro
+[[ $(uname -r) == *rt* ]] && [[ $current == $rt_lts_base ]] && current=linux-rt-lts-manjaro
 
 case "$1" in
     -h | --help)            args_check $# 1 1


### PR DESCRIPTION
I've tested this thorrowly running different kernels and all possible scenarios I could think of and everything seems to work fine.

kernel_repo()
![](http://imgur.com/68pKtAll.png)

kernel_list()
![](http://imgur.com/uCZWWdyl.png)

Some stuff is even a little fancier now :wink:
![](http://imgur.com/Ag4q1b2l.png)

The only little flaw is that when rt switches to a different basekernel this has to be adjusted manually until someone comes up with a more brilliant solution than this:
```
rt_base=linux46
rt_lts_base=linux44

IFS=. read -r major minor _ <<< "$(uname -r)"
current="linux$major$minor"
[[ $(uname -r) == *rt* ]] && [[ $current == $rt_base ]] && current=linux-rt-manjaro
[[ $(uname -r) == *rt* ]] && [[ $current == $rt_lts_base ]] && current=linux-rt-lts-manjaro
```